### PR TITLE
Add persistent SQLite storage for activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # Logs and databases #
 ######################
 *.log
+*.db
 *.sql
 *.sqlite
 

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,8 +20,9 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+DB_PATH = current_dir / "activities.db"
+
+DEFAULT_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -78,6 +80,99 @@ activities = {
 }
 
 
+def get_connection():
+    connection = sqlite3.connect(DB_PATH)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def seed_default_activities(connection):
+    for name, data in DEFAULT_ACTIVITIES.items():
+        connection.execute(
+            """
+            INSERT INTO activities(name, description, schedule, max_participants)
+            VALUES (?, ?, ?, ?)
+            """,
+            (name, data["description"], data["schedule"], data["max_participants"])
+        )
+
+        connection.executemany(
+            """
+            INSERT INTO activity_participants(activity_name, email)
+            VALUES (?, ?)
+            """,
+            [(name, email) for email in data["participants"]]
+        )
+
+
+def init_database():
+    with get_connection() as connection:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                name TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS activity_participants (
+                activity_name TEXT NOT NULL,
+                email TEXT NOT NULL,
+                PRIMARY KEY (activity_name, email),
+                FOREIGN KEY (activity_name) REFERENCES activities(name) ON DELETE CASCADE
+            );
+            """
+        )
+
+        activity_count = connection.execute(
+            "SELECT COUNT(*) AS count FROM activities"
+        ).fetchone()["count"]
+
+        if activity_count == 0:
+            seed_default_activities(connection)
+
+
+def fetch_activities():
+    with get_connection() as connection:
+        activity_rows = connection.execute(
+            """
+            SELECT name, description, schedule, max_participants
+            FROM activities
+            ORDER BY name
+            """
+        ).fetchall()
+
+        participant_rows = connection.execute(
+            """
+            SELECT activity_name, email
+            FROM activity_participants
+            ORDER BY email
+            """
+        ).fetchall()
+
+    activities = {
+        row["name"]: {
+            "description": row["description"],
+            "schedule": row["schedule"],
+            "max_participants": row["max_participants"],
+            "participants": []
+        }
+        for row in activity_rows
+    }
+
+    for row in participant_rows:
+        activities[row["activity_name"]]["participants"].append(row["email"])
+
+    return activities
+
+
+@app.on_event("startup")
+def startup_event():
+    init_database()
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -85,48 +180,82 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return fetch_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as connection:
+        activity = connection.execute(
+            "SELECT max_participants FROM activities WHERE name = ?",
+            (activity_name,)
+        ).fetchone()
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        is_already_signed_up = connection.execute(
+            """
+            SELECT 1
+            FROM activity_participants
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email)
+        ).fetchone()
+
+        if is_already_signed_up:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            )
+
+        signup_count = connection.execute(
+            "SELECT COUNT(*) AS count FROM activity_participants WHERE activity_name = ?",
+            (activity_name,)
+        ).fetchone()["count"]
+
+        if signup_count >= activity["max_participants"]:
+            raise HTTPException(status_code=400, detail="Activity is full")
+
+        connection.execute(
+            "INSERT INTO activity_participants(activity_name, email) VALUES (?, ?)",
+            (activity_name, email)
         )
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as connection:
+        activity = connection.execute(
+            "SELECT 1 FROM activities WHERE name = ?",
+            (activity_name,)
+        ).fetchone()
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        is_signed_up = connection.execute(
+            """
+            SELECT 1
+            FROM activity_participants
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email)
+        ).fetchone()
+
+        if not is_signed_up:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
+
+        connection.execute(
+            "DELETE FROM activity_participants WHERE activity_name = ? AND email = ?",
+            (activity_name, email)
         )
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- replace in-memory activity storage with SQLite-backed persistence
- initialize and seed the activities database at app startup
- keep existing API responses while using DB reads/writes for signup and unregister
- ignore generated .db files in git

## Validation
- backend sanity check script run locally:
  - initialized DB and loaded 9 activities
  - signup persisted successfully
  - unregister removed participant successfully

Closes #5